### PR TITLE
Adjust `RandomGen` instance to work with new `random-1.2`

### DIFF
--- a/System/Random/Mersenne/Pure64.hs
+++ b/System/Random/Mersenne/Pure64.hs
@@ -79,8 +79,13 @@ newPureMT = do
 -- RandomGen. However, it doesn't support 'split' yet.
 
 instance RandomGen PureMT where
-   next  = randomInt
+   next = randomInt
    split = error "System.Random.Mersenne.Pure: unable to split the mersenne twister"
+#if MIN_VERSION_random(1, 2, 0)
+   genWord32 g = (fromIntegral i, g')
+        where (i, g') = randomWord64 g
+   genWord64 = randomWord64
+#endif
 
 ------------------------------------------------------------------------
 -- Direct access to Int, Word and Double types


### PR DESCRIPTION
New version of random was released today. This minor change improves the performance drastically, since going through `next` is way slower. Also `next` and `genRange` have been deprecated