### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/mersenne-random-pure64.cabal
+++ b/mersenne-random-pure64.cabal
@@ -24,7 +24,7 @@ license-file:    LICENSE
 copyright:       (c) 2008. Don Stewart <dons00@gmail.com>
 author:          Don Stewart
 maintainer:      Don Stewart <dons00@gmail.com>
-cabal-version:   >= 1.6.0
+cabal-version:   >= 1.8
 build-type:      Simple
 tested-with:     GHC == 7.6.2, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.1
 


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: mersenne-random-pure64.cabal:49:36: version operators used. To use
version operators the package needs to specify at least 'cabal-version: >=
1.8'.
```